### PR TITLE
disable tiered compilation for benchmark runs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,7 @@
                                         [clj-message-digest "1.0.0"]
                                         [digest "1.4.4"]]
                          :source-paths ["shootout"]
-                         :jvm-opts ["-Xmx1g" "-server"]}
+                         :jvm-opts ^:replace ["-Xmx1g" "-server"]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}}
 
   :prep-tasks ["codegen"]


### PR DESCRIPTION
by default, leiningen sets the JVM up for startup time, via tiered
compilation (see https://github.com/technomancy/leiningen/wiki/Faster).
This doesn't play properly with benchmarks, because it disables the more
aggressive JIT optimizations, which can (but don't always) have a severe
impact on benchmark results. You have to use `^:replace` on `:jvm-opts` to
accomplish this.

output from runs before/after (run on a laptop though, so not all *that* useful):
https://gist.github.com/tcrayford/839fd9f9ab066f76cce9