### PR TITLE
Replace count With alength for Performance Reasons

### DIFF
--- a/src/clojure/pandect/utils/convert.clj
+++ b/src/clojure/pandect/utils/convert.clj
@@ -14,7 +14,7 @@
   "Convert Byte Array to Hex String"
   ^String
   [^"[B" data]
-  (let [len (count data)
+  (let [len (alength data)
         ^"[B" buffer (byte-array (* 2 len))]
     (loop [i 0]
       (when (< i len)


### PR DESCRIPTION
count is quite slow on arrays because it works on many types which are
checked in a long chain of if statements where arrays come last.

I get a improvement of MD5 Hello World Hashing from 750 ns to 630 ns.