### PR TITLE
make ns conform to spec, for clojure 1.9 compatibility

### DIFF
--- a/src/clojure/pandect/impl/checksum.clj
+++ b/src/clojure/pandect/impl/checksum.clj
@@ -1,8 +1,7 @@
 (ns ^:no-doc pandect.impl.checksum
-  (:require [pandect.gen
-             [core :refer :all]
-             [hash-generator :refer :all]
-             [hmac-generator :refer :all]]
+  (:require [pandect.gen.core :refer :all]
+            [pandect.gen.hash-generator :refer :all]
+            [pandect.gen.hmac-generator :refer :all]
             [pandect.utils.convert :as c :only [long->4-bytes]])
   (:import [java.util.zip Adler32 CRC32]))
 


### PR DESCRIPTION
Version `0.6.1` is not compatible to Clojure 1.9 due to an invalid ns form.

```
clojure.lang.ExceptionInfo: Call to clojure.core/ns did not conform to spec.
        clojure.spec.alpha/args: (pandect.impl.checksum
                                  (:require
                                   [pandect.gen
                                    [core :refer :all]
                                    [hash-generator :refer :all]
                                    [hmac-generator :refer :all]]
                                   [pandect.utils.convert :as c only [long->4-bytes]])
                                  (:import [java.util.zip Adler32 CRC32]))
    clojure.spec.alpha/problems: [{:path [],
                                   :reason "Extra input",
                                   :pred
                                   (clojure.spec.alpha/cat
                                    :docstring
                                    (clojure.spec.alpha/? clojure.core/string?)
                                    :attr-map
                                    (clojure.spec.alpha/? clojure.core/map?)
                                    :ns-clauses
                                    :clojure.core.specs.alpha/ns-clauses),
                                   :val
                                   ((:require
                                     [pandect.gen
                                      [core :refer :all]
                                      [hash-generator :refer :all]
                                      [hmac-generator :refer :all]]
                                     [pandect.utils.convert :as c only [long->4-bytes]])
                                    (:import [java.util.zip Adler32 CRC32])),
                                   :via [:clojure.core.specs.alpha/ns-form],
                                   :in [1]}]
        clojure.spec.alpha/spec: #object[clojure.spec.alpha$regex_spec_impl$reify__2509 0x49433c98 "clojure.spec.alpha$regex_spec_impl$reify__2509@49433c98"]
       clojure.spec.alpha/value: (pandect.impl.checksum
                                  (:require
                                   [pandect.gen
                                    [core :refer :all]
                                    [hash-generator :refer :all]
                                    [hmac-generator :refer :all]]
                                   [pandect.utils.convert :as c only [long->4-bytes]])
                                  (:import [java.util.zip Adler32 CRC32]))
```