### PR TITLE
Inline potemkin code, remove repackaging

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,9 +7,7 @@
             :year 2014
             :key "mit"}
   :dependencies [[org.clojure/clojure "1.10.1" :scope "provided"]
-                 [org.bouncycastle/bcprov-jdk15on "1.68" :scope "provided"]
-                 ^:inline-dep [potemkin "0.4.5"]
-                 ^:inline-dep [riddley "0.2.0"]]
+                 [org.bouncycastle/bcprov-jdk15on "1.68" :scope "provided"]]
   :profiles {:dev
              {:dependencies [[perforate "0.3.4"]]
               :plugins [[perforate "0.3.4"]]
@@ -38,8 +36,6 @@
               {:global-vars {*warn-on-reflection* false}}]}
 
   :prep-tasks [["codegen"]]
-  :plugins [[lein-isolate "0.2.2-SNAPSHOT"]]
-  :middleware [leiningen.isolate/middleware]
 
   :aliases {"kaocha"    ["with-profile" "+kaocha" "run" "-m" "kaocha.runner"]
             "ci"        ["with-profile" "+ci" "run" "-m" "kaocha.runner"

--- a/src/pandect/core.clj
+++ b/src/pandect/core.clj
@@ -2,7 +2,7 @@
       :author "Yannick Scherer"}
   pandect.core
   (:require [pandect.buffer]
-            [potemkin :refer [import-vars]]
+            [pandect.utils.import-defs :refer [import-vars]]
             [pandect.codegen :refer [algorithms algorithm-namespace]]))
 
 ;; ## Re-export all algorithms

--- a/src/pandect/utils/import_defs.clj
+++ b/src/pandect/utils/import_defs.clj
@@ -1,0 +1,120 @@
+(ns ^:no-doc pandect.utils.import-defs)
+
+;; Copyright 2013 Zachary Tellman
+;;
+;; Permission is hereby granted, free of charge, to any person obtaining a copy
+;; of this software and associated documentation files (the "Software"), to
+;; deal in the Software without restriction, including without limitation the
+;; rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+;; sell copies of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+;;
+;; The above copyright notice and this permission notice shall be included in
+;; all copies or substantial portions of the Software.
+;;
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+;; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;; FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+;; IN THE SOFTWARE.
+
+(defn link-vars
+  "Makes sure that all changes to `src` are reflected in `dst`."
+  [src dst]
+  (add-watch src dst
+             (fn [_ src _ _]
+               (alter-var-root dst (constantly @src))
+               (alter-meta! dst merge (dissoc (meta src) :name)))))
+
+(defmacro import-fn
+  "Given a function in another namespace, defines a function with the
+  same name in the current namespace.  Argument lists, doc-strings,
+  and original line-numbers are preserved."
+  ([sym]
+   `(import-fn ~sym nil))
+  ([sym name]
+   (let [vr (resolve sym)
+         m (meta vr)
+         n (or name (:name m))
+         protocol (:protocol m)]
+     (when-not vr
+       (throw (IllegalArgumentException. (str "Don't recognize " sym))))
+     (when (:macro m)
+       (throw (IllegalArgumentException.
+                (str "Calling import-fn on a macro: " sym))))
+
+     `(do
+        (def ~(with-meta n {:protocol protocol}) (deref ~vr))
+        (alter-meta! (var ~n) merge (dissoc (meta ~vr) :name))
+        (link-vars ~vr (var ~n))
+        ~vr))))
+
+(defmacro import-macro
+  "Given a macro in another namespace, defines a macro with the same
+  name in the current namespace.  Argument lists, doc-strings, and
+  original line-numbers are preserved."
+  ([sym]
+   `(import-macro ~sym nil))
+  ([sym name]
+   (let [vr (resolve sym)
+         m (meta vr)
+         n (or name (with-meta (:name m) {}))]
+     (when-not vr
+       (throw (IllegalArgumentException. (str "Don't recognize " sym))))
+     (when-not (:macro m)
+       (throw (IllegalArgumentException.
+                (str "Calling import-macro on a non-macro: " sym))))
+     `(do
+        (def ~n ~(resolve sym))
+        (alter-meta! (var ~n) merge (dissoc (meta ~vr) :name))
+        (.setMacro (var ~n))
+        (link-vars ~vr (var ~n))
+        ~vr))))
+
+(defmacro import-def
+  "Given a regular def'd var from another namespace, defined a new var with the
+  same name in the current namespace."
+  ([sym]
+   `(import-def ~sym nil))
+  ([sym name]
+   (let [vr (resolve sym)
+         m (meta vr)
+         n (or name (:name m))
+         n (with-meta n (if (:dynamic m) {:dynamic true} {}))]
+     (when-not vr
+       (throw (IllegalArgumentException. (str "Don't recognize " sym))))
+     `(do
+        (def ~n @~vr)
+        (alter-meta! (var ~n) merge (dissoc (meta ~vr) :name))
+        (link-vars ~vr (var ~n))
+        ~vr))))
+
+(defmacro import-vars
+  "Imports a list of vars from other namespaces."
+  [& syms]
+  (let [unravel (fn unravel [x]
+                  (if (sequential? x)
+                    (->> x
+                         rest
+                         (mapcat unravel)
+                         (map
+                           #(symbol
+                              (str (first x)
+                                   (when-let [n (namespace %)]
+                                     (str "." n)))
+                              (name %))))
+                    [x]))
+        syms (mapcat unravel syms)]
+    `(do
+       ~@(map
+           (fn [sym]
+             (let [vr (resolve sym)
+                   m (meta vr)]
+               (cond
+                 (nil? vr) `(throw (ex-info (format "`%s` does not exist" '~sym) {}))
+                 (:macro m) `(import-macro ~sym)
+                 (:arglists m) `(import-fn ~sym)
+                 :else `(import-def ~sym))))
+           syms))))


### PR DESCRIPTION
Repackaging is currently problematic due to an issue with mranderson. However, since we're only using a single potemkin namespace (and none of riddley), we can just inline the code we need and remove the dependencies, as well as the repackaging.

Fixes #22.